### PR TITLE
12 | Create Schema For Hero Section

### DIFF
--- a/src/sanity/schemaTypes/index.ts
+++ b/src/sanity/schemaTypes/index.ts
@@ -1,5 +1,6 @@
 import type { SchemaTypeDefinition } from "sanity";
+import profile from "@/sanity/schemaTypes/profile";
 
 export const schema: { types: SchemaTypeDefinition[] } = {
-  types: [],
+  types: [profile],
 };

--- a/src/sanity/schemaTypes/profile.ts
+++ b/src/sanity/schemaTypes/profile.ts
@@ -1,0 +1,172 @@
+import { defineField, defineType } from "sanity";
+
+export default defineType({
+  name: "profile",
+  title: "Profile",
+  type: "document",
+  fields: [
+    defineField({
+      name: "firstName",
+      title: "First Name",
+      type: "string",
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: "lastName",
+      title: "Last Name",
+      type: "string",
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: "title",
+      title: "Title",
+      type: "string",
+      description: "E.g. 'Full Stack Developer'",
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: "headlineStaticText",
+      title: "Headline Static Text",
+      type: "string",
+      description: "Static part of the animated headline",
+    }),
+    defineField({
+      name: "headlineAnimatedText",
+      title: "Headline Animated Text",
+      type: "array",
+      of: [{ type: "string" }],
+      description: "Words that will be animated through",
+      validation: (Rule) => Rule.min(2).max(10),
+    }),
+    defineField({
+      name: "headlineAnimationDuration",
+      title: "Headline Animation Duration",
+      type: "number",
+      description:
+        "How long each word is visible before the next one is rendered",
+      initialValue: 3000,
+      validation: (Rule) => Rule.required().max(10000),
+    }),
+    defineField({
+      name: "shortDescription",
+      title: "Short Description",
+      type: "text",
+      rows: 3,
+      description: "Brief description of yourself",
+      validation: (Rule) => Rule.required().max(300),
+    }),
+    defineField({
+      name: "bio",
+      title: "Bio",
+      type: "array",
+      of: [{ type: "block" }],
+      description: "Detailed description of yourself",
+    }),
+    defineField({
+      name: "profileImage",
+      title: "Profile Image",
+      type: "image",
+      options: {
+        hotspot: true,
+      },
+      fields: [
+        {
+          name: "alt",
+          type: "string",
+          title: "Alternative Text",
+        },
+      ],
+    }),
+    defineField({
+      name: "email",
+      title: "Email",
+      type: "string",
+      validation: (Rule) => Rule.required().email(),
+    }),
+    defineField({
+      name: "location",
+      title: "Location",
+      type: "string",
+    }),
+    defineField({
+      name: "availability",
+      title: "Availability Status",
+      type: "string",
+      options: {
+        list: [
+          { title: "Available for hire", value: "available" },
+          { title: "Open to opportunities", value: "open" },
+          { title: "Not looking", value: "unavailable" },
+        ],
+      },
+    }),
+    defineField({
+      name: "socialLinks",
+      title: "Social Links",
+      type: "object",
+      fields: [
+        { name: "github", title: "GitHub", type: "url" },
+        { name: "linkedin", title: "LinkedIn", type: "url" },
+        { name: "twitter", title: "Twitter/X", type: "url" },
+        { name: "website", title: "Personal Website", type: "url" },
+        { name: "medium", title: "Medium", type: "url" },
+        { name: "devto", title: "Dev.to", type: "url" },
+        { name: "youtube", title: "YouTube", type: "url" },
+        { name: "stackoverflow", title: "Stack Overflow", type: "url" },
+      ],
+    }),
+    defineField({
+      name: "yearsOfExperience",
+      title: "Years of Experience",
+      type: "number",
+      validation: (Rule) => Rule.min(0),
+    }),
+    defineField({
+      name: "stats",
+      title: "Profile Statistics",
+      type: "array",
+      description: "Key statistics to display on your about section",
+      of: [
+        {
+          type: "object",
+          fields: [
+            {
+              name: "label",
+              title: "Label",
+              type: "string",
+              validation: (Rule) => Rule.required(),
+            },
+            {
+              name: "value",
+              title: "Value",
+              type: "string",
+              description: "E.g., '50+', '100%', '24/7'",
+              validation: (Rule) => Rule.required(),
+            },
+          ],
+          preview: {
+            select: {
+              title: "label",
+              subtitle: "value",
+            },
+          },
+        },
+      ],
+    }),
+  ],
+  preview: {
+    select: {
+      title: "firstName",
+      subtitle: "title",
+      media: "profileImage",
+    },
+    prepare(selection) {
+      const { title, subtitle, media } = selection;
+      return {
+        title: title,
+        subtitle: subtitle,
+        media: media,
+      };
+    },
+  },
+});

--- a/src/sanity/structure.ts
+++ b/src/sanity/structure.ts
@@ -1,5 +1,15 @@
+import { UserIcon } from "@sanity/icons";
 import type { StructureResolver } from "sanity/structure";
 
 // https://www.sanity.io/docs/structure-builder-cheat-sheet
 export const structure: StructureResolver = (S) =>
-  S.list().title("Content").items(S.documentTypeListItems());
+  S.list()
+    .title("Portfolio Content")
+    .items([
+      S.listItem()
+        .title("Profile")
+        .icon(UserIcon)
+        .child(
+          S.document().schemaType("profile").documentId("singleton-profile"),
+        ),
+    ]);


### PR DESCRIPTION
## Description
Initially this was meant to be the schema for just the hero section, however after consideration it was decided that single schema containing all details about me would be better for the entire project. So instead a profile schema was created.

Only one of these should exist so Sanity was setup to only allow one document of this type.

## Type of Change
- [X] New feature

## How Has This Been Tested?
Schema was filled out.

## Checklist
- [X] Code was run locally.
- [X] Pre-commit was run and formatting/linting succeeded.
- [X] Code follows style guidelines / Self-review performed / Tests added.
